### PR TITLE
[FIX] Add fixes

### DIFF
--- a/mis_builder/migrations/8.0.2.0.0/pre-migration.py
+++ b/mis_builder/migrations/8.0.2.0.0/pre-migration.py
@@ -1,20 +1,38 @@
-# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+# Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
 
 
-def migrate(cr, version):
-    cr.execute(
-        """
-        ALTER TABLE mis_report_kpi
-        RENAME COLUMN expression TO old_expression
-    """
-    )
-    # this migration to date_range type is partial,
-    # actual date ranges needs to be created manually
-    cr.execute(
-        """
-        UPDATE mis_report_instance_period
-        SET type='date_range'
-        WHERE type='fp'
-    """
-    )
+@openupgrade.migrate()
+def migrate(env, version):
+    old_column = "auto_expand_accounts"
+    new_column = "auto_expand"
+
+    if not openupgrade.column_exists(env.cr, "mis_report", new_column):
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "mis.report",
+                    "mis_report",
+                    old_column,
+                    new_column,
+                ),
+            ],
+        )
+    
+    old_column = "auto_expand_accounts_style_id"
+    new_column = "auto_expand_style_id"
+
+    if not openupgrade.column_exists(env.cr, "mis_report", new_column):
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "mis.report",
+                    "mis_report",
+                    old_column,
+                    new_column,
+                ),
+            ],
+        )

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -431,66 +431,6 @@ class AccountingExpressionProcessor(object):
 
         return self._ACC_RE.sub(f, expr)
 
-    def replace_exprs_by_account_id(self, exprs):
-        """This method is depreciated and replaced by replace_exprs_by_row_detail.
-
-        Replace accounting variables in a list of expression
-        by their amount, iterating by accounts involved in the expression.
-        yields account_id, replaced_expr
-        This method must be executed after do_queries().
-        """
-
-        def f(mo):
-            field, mode, acc_domain, ml_domain = self._parse_match_object(mo)
-            key = (ml_domain, mode)
-            # first check if account_id is involved in
-            # the current expression part
-            if account_id not in self._account_ids_by_acc_domain[acc_domain]:
-                return "(AccountingNone)"
-            # here we know account_id is involved in acc_domain
-            account_ids_data = self._data[key][UNCLASSIFIED_ROW_DETAIL]
-            debit, credit = account_ids_data.get(
-                account_id, (AccountingNone, AccountingNone)
-            )
-            if field == "bal":
-                v = debit - credit
-            elif field == "pbal":
-                if debit >= credit:
-                    v = debit - credit
-                else:
-                    v = AccountingNone
-            elif field == "nbal":
-                if debit < credit:
-                    v = debit - credit
-                else:
-                    v = AccountingNone
-            elif field == "deb":
-                v = debit
-            elif field == "crd":
-                v = credit
-            # in initial balance mode, assume 0 is None
-            # as it does not make sense to distinguish 0 from "no data"
-            if (
-                v is not AccountingNone
-                and mode in (self.MODE_INITIAL, self.MODE_UNALLOCATED)
-                and float_is_zero(v, precision_digits=self.dp)
-            ):
-                v = AccountingNone
-            return "(" + repr(v) + ")"
-
-        account_ids = set()
-        for expr in exprs:
-            for mo in self._ACC_RE.finditer(expr):
-                field, mode, acc_domain, ml_domain = self._parse_match_object(mo)
-                key = (ml_domain, mode)
-                account_ids_data = self._data[key][UNCLASSIFIED_ROW_DETAIL]
-                for account_id in self._account_ids_by_acc_domain[acc_domain]:
-                    if account_id in account_ids_data:
-                        account_ids.add(account_id)
-
-        for account_id in account_ids:
-            yield account_id, [self._ACC_RE.sub(f, expr) for expr in exprs]
-
     def replace_exprs_by_row_detail(self, exprs):
         """Replace accounting variables in a list of expression
         by their amount, iterating by accounts involved in the expression.

--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -471,9 +471,9 @@ class KpiMatrix(object):
         rdi_ids = list(rdi_ids)
         if UNCLASSIFIED_ROW_DETAIL in rdi_ids:
             rdi_ids.remove(UNCLASSIFIED_ROW_DETAIL)
-        rdis = self._rdi_model.search([("id", "in", rdi_ids)])
+        rdis = self._rdi_model.with_context(test_active=False).search([("id", "in", rdi_ids)])
         self._rdi_names = {rdi.id: self._get_rdi_name(rdi) for rdi in rdis}
-        self._rdi_names[UNCLASSIFIED_ROW_DETAIL] = _("Other")
+        self._rdi_names[UNCLASSIFIED_ROW_DETAIL] = _("(not set)")
 
     def _get_rdi_name(self, rdi):
         result = rdi.name_get()[0][1]

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -92,9 +92,8 @@ class MisReportKpi(models.Model):
         string="Expressions",
     )
 
-    # TODO : this fields should be renamed to auto_expand_details or something like this
-    auto_expand_accounts = fields.Boolean(string="Display details")
-    auto_expand_accounts_style_id = fields.Many2one(
+    auto_expand = fields.Boolean(string="Display details")
+    auto_expand_style_id = fields.Many2one(
         string="Style for details rows", comodel_name="mis.report.style", required=False
     )
     style_id = fields.Many2one(
@@ -767,7 +766,7 @@ class MisReport(models.Model):
                     continue
 
                 rdis = expression_evaluator.eval_expressions_by_row_detail(
-                    expressions, locals_dict  # , self.auto_expand_col_name
+                    expressions, locals_dict
                 )
                 for (rdi, vals, drilldown_args, _name_error) in rdis:
                     for drilldown_arg in drilldown_args:

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -381,7 +381,7 @@ class TestMisReportInstance(common.HttpCase):
         matrix = self.report_instance._compute_matrix()
         for row in matrix.iter_rows():
             if row.row_detail_identifier:
-                account = self.env["account.account"].browse(row.row_detail_identifier)
+                account = self.env[row.row_detail_model].browse(row.row_detail_identifier)
                 self.assertEqual(
                     row.label,
                     "%s [%s]" % (account.name_get()[0][1], account.company_id.name),
@@ -390,7 +390,7 @@ class TestMisReportInstance(common.HttpCase):
         matrix = self.report_instance._compute_matrix()
         for row in matrix.iter_rows():
             if row.row_detail_identifier:
-                account = self.env["account.account"].browse(row.row_detail_identifier)
+                account = self.env[row.row_detail_model].browse(row.row_detail_identifier)
                 self.assertEqual(row.label, account.name_get()[0][1])
 
     def test_evaluate(self):


### PR DESCRIPTION
- Rename `auto_expand_accounts`
- Rename `auto_expand_accounts_style_id`
- Removed legacy functions
- From _('Other') => _('(not set)')
- Test From `account.account` to `row.row_detail_model`

Sorry if the contributions are small, but I think the module is ready to make the merge, the only change that I see important is the `test_active=False` as it produces a false data error, for the rest I see a very good job.